### PR TITLE
add ability of verifying a msg with a pk only

### DIFF
--- a/src/Crypto/sr25519.php
+++ b/src/Crypto/sr25519.php
@@ -62,11 +62,11 @@ class sr25519
      * @param string $signature signature
      * @return bool
      */
-    public function VerifySign (keyPair $pair, string $msg, string $signature): bool
+    public function VerifySign (keyPair|string $pairOrPk, string $msg, string $signature): bool
     {
-
+        $pk = $pairOrPk instanceof keyPair ? $pairOrPk->publicKey : $pairOrPk;
         $result = $this->FFIInstant->VerifySign(
-            Utils::convertGoString($this->FFIInstant, $pair->publicKey),
+            Utils::convertGoString($this->FFIInstant, $pk),
             Utils::convertGoString($this->FFIInstant, $msg),
             Utils::convertGoString($this->FFIInstant, $signature));
         return $this->FFIInstant::string($result) == "true";


### PR DESCRIPTION
Hello @gmajor-encrypt ,

If you find it suitable I would like to include a string/pk only in this function. A very common use case for verifying a message would be to have only the public key of the user who sent the message. Instead of a keypair (which takes a public and private key).